### PR TITLE
Simplicity and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This extension adds the following feeds to Flarum:
 
 You can replace `atom` by `rss` in the URLs above to get RSS feeds instead. The tags-related feeds are only available if the tags extension is installed and enabled.
 
-The difference between this fork and the original is that this fork has tweaked a couple things to ensure the feeds validate.
+Feeds are linked in the pages for autodiscovery and listing in the browser (at least in Firefox, as Chrome, Vivaldi, and a lot of others doesn't support syndication feeds out of the box). This said, they are not dynamically updated as the page change (except when fully reloaded), becuse of this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=380639). If a workaround is found, they will be.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This extension adds the following feeds to Flarum:
 
 You can replace `atom` by `rss` in the URLs above to get RSS feeds instead. The tags-related feeds are only available if the tags extension is installed and enabled.
 
-Feeds are linked in the pages for autodiscovery and listing in the browser (at least in Firefox, as Chrome, Vivaldi, and a lot of others doesn't support syndication feeds out of the box). This said, they are not dynamically updated as the page change (except when fully reloaded), becuse of this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=380639). If a workaround is found, they will be.
+The difference between this fork and the original is that this fork has tweaked a couple things to ensure the feeds validate.

--- a/views/atom.blade.nonHTML.php
+++ b/views/atom.blade.nonHTML.php
@@ -1,0 +1,25 @@
+{!! '<'.'?xml version="1.0" encoding="utf-8"?'.'>' !!}
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+    <title><![CDATA[{!! $title !!}]]></title>
+    <subtitle><![CDATA[{!! $description !!}]]></subtitle>
+    <link href="{{ $self_link }}" rel="self" />
+    <link href="{{ $link }}/" />
+    <id><![CDATA[{!! $link !!}/]]></id>
+    <updated>{{ $pubDate->format(DateTime::ATOM) }}</updated>
+
+    @foreach ($entries as $entry)
+    <entry>
+        <title><![CDATA[{!! $entry['title'] !!}]]></title>
+        <link rel="alternate" type="text/html" href="{{ $entry['permalink'] }}"/>
+        <id>{{ $entry['permalink'] }}</id>
+        <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
+        <summary><![CDATA[{!! $entry['description'] !!}]]></summary>
+        <author>
+            <name>{{ $entry['author'] }}</name>
+        </author>
+    </entry>
+    @endforeach
+
+</feed>

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -13,10 +13,9 @@
     <entry>
         <title><![CDATA[{!! $entry['title'] !!}]]></title>
         <link rel="alternate" type="text/html" href="{{ $entry['permalink'] }}"/>
-        <id>{{ $entry['id'] or $entry['permalink'] }}</id>
+        <id>{{ $entry['permalink'] }}</id>
         <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
         <summary><![CDATA[{!! $entry['description'] !!}]]></summary>
-        <content type="html"><![CDATA[{!! $entry['content'] or $entry['description'] !!}]]></content>
         <author>
             <name>{{ $entry['author'] }}</name>
         </author>

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -15,7 +15,7 @@
         <link rel="alternate" type="text/html" href="{{ $entry['permalink'] }}"/>
         <id>{{ $entry['permalink'] }}</id>
         <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
-        <summary type="html"><![CDATA[{!! $entry['content'] !!}]]></summary>
+        <content type="html"><![CDATA[{!! $entry['content'] !!}]]></content>
         <author>
             <name>{{ $entry['author'] }}</name>
         </author>

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -15,7 +15,7 @@
         <link rel="alternate" type="text/html" href="{{ $entry['permalink'] }}"/>
         <id>{{ $entry['permalink'] }}</id>
         <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
-        <summary><![CDATA[{!! $entry['description'] !!}]]></summary>
+        <summary type="html"><![CDATA[{!! $entry['description'] !!}]]></summary>
         <author>
             <name>{{ $entry['author'] }}</name>
         </author>

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -15,7 +15,7 @@
         <link rel="alternate" type="text/html" href="{{ $entry['permalink'] }}"/>
         <id>{{ $entry['permalink'] }}</id>
         <updated>{{ $entry['pubdate']->format(DateTime::ATOM) }}</updated>
-        <summary type="html"><![CDATA[{!! $entry['description'] !!}]]></summary>
+        <summary type="html"><![CDATA[{!! $entry['content'] !!}]]></summary>
         <author>
             <name>{{ $entry['author'] }}</name>
         </author>

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -4,9 +4,9 @@
 
     <title><![CDATA[{!! $title !!}]]></title>
     <subtitle><![CDATA[{!! $description !!}]]></subtitle>
-    <link href="{{ $self_link }}" rel="self" />
-    <link href="{{ $link }}" />
-    <id><![CDATA[{!! $link !!}]]></id>
+    <link href="{{ $self_link }}/" rel="self" />
+    <link href="{{ $link }}/" />
+    <id><![CDATA[{!! $link !!}/]]></id>
     <updated>{{ $pubDate->format(DateTime::ATOM) }}</updated>
 
     @foreach ($entries as $entry)

--- a/views/atom.blade.php
+++ b/views/atom.blade.php
@@ -4,7 +4,7 @@
 
     <title><![CDATA[{!! $title !!}]]></title>
     <subtitle><![CDATA[{!! $description !!}]]></subtitle>
-    <link href="{{ $self_link }}/" rel="self" />
+    <link href="{{ $self_link }}" rel="self" />
     <link href="{{ $link }}/" />
     <id><![CDATA[{!! $link !!}/]]></id>
     <updated>{{ $pubDate->format(DateTime::ATOM) }}</updated>

--- a/views/rss.blade.nonHTML.php
+++ b/views/rss.blade.nonHTML.php
@@ -1,0 +1,23 @@
+{!! '<'.'?xml version="1.0" encoding="utf-8"?'.'>' !!}
+
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">
+
+    <channel>
+        <title><![CDATA[{!! $title !!}]]></title>
+        @if (!empty($description))<description><![CDATA[{!! $description !!}]]></description>@endif
+        <link><![CDATA[{!! $link !!}]]></link>
+        <pubDate>{{ $pubDate->format(DateTime::RSS) }}</pubDate>
+        <atom:link href="{{ $self_link }}" rel="self" type="application/rss+xml" />
+
+        @foreach ($entries as $entry)
+        <item>
+            <title><![CDATA[{!! $entry['title'] !!}]]></title>
+            <description><![CDATA[{!! $entry['description'] !!}]]></description>
+            <guid>{{ $entry['permalink'] }}</guid>
+            <pubDate>{{ $entry['pubdate']->format(DateTime::RSS) }}</pubDate>
+        </item>
+        @endforeach
+
+    </channel>
+
+</rss>

--- a/views/rss.blade.php
+++ b/views/rss.blade.php
@@ -13,9 +13,7 @@
         <item>
             <title><![CDATA[{!! $entry['title'] !!}]]></title>
             <description><![CDATA[{!! $entry['description'] !!}]]></description>
-            <content:encoded><![CDATA[{!! $entry['content'] or $entry['description'] !!}]]></content:encoded>
-            <link>{{ $entry['permalink'] }}</link>
-            <guid isPermaLink="{{ !isset($entry['id']) }}">{{ $entry['id'] or $entry['permalink'] }}</guid>
+            <guid>{{ $entry['permalink'] }}</guid>
             <pubDate>{{ $entry['pubdate']->format(DateTime::RSS) }}</pubDate>
         </item>
         @endforeach

--- a/views/rss.blade.php
+++ b/views/rss.blade.php
@@ -12,7 +12,7 @@
         @foreach ($entries as $entry)
         <item>
             <title><![CDATA[{!! $entry['title'] !!}]]></title>
-            <description><![CDATA[{!! $entry['description'] !!}]]></description>
+            <description><![CDATA[{!! $entry['content'] !!}]]></description>
             <guid>{{ $entry['permalink'] }}</guid>
             <pubDate>{{ $entry['pubdate']->format(DateTime::RSS) }}</pubDate>
         </item>


### PR DESCRIPTION
These changes make things simple, ensure the feeds validate, and keep the feed post content text only versus trying to include HTML. This last part is admittedly a personal preference. I do not think we need the feeds to include the full HTML for posts. Plain text descriptions/summaries should suffice and help to ensure validation and feed reader compatibility.

The main reason I started making these changes is because the ID portion of the atom feed wasn’t validating. It was only pulling in the post ID which happens to be “1” every time. This pull request makes the ID the full permalink which validates.